### PR TITLE
fix: remediate QRadar connector findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.6
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: QRadar
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -830,7 +830,6 @@ action_result.data.\*.File Size | string | | |
 action_result.data.\*.Flow Direction Algorithm | numeric | | 5 |
 action_result.data.\*.Google Search Terms | string | | |
 action_result.data.\*.Originating User | string | | |
-action_result.data.\*.Password | string | | |
 action_result.data.\*.Recipient Users.\* | string | | |
 action_result.data.\*.Request URL | string | | |
 action_result.data.\*.Search Arguments | string | | |

--- a/README.md
+++ b/README.md
@@ -1363,7 +1363,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/default_timezones.py
+++ b/default_timezones.py
@@ -1,6 +1,6 @@
 # File: default_timezones.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ https://github.com/prefrontal/dateutil-parser-timezones
 
 MIT License
 
-Copyright (c) 2016-2025 Craig Bennett
+Copyright (c) 2016-2026 Craig Bennett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/display_qr.html
+++ b/display_qr.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: display_qr.html
-  Copyright (c) 2016-2025 Splunk Inc.
+  Copyright (c) 2016-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/display_qr.html
+++ b/display_qr.html
@@ -125,7 +125,7 @@ and limitations under the License.
                   <td>
                     {% if curr_contains_data|by_key:hdr_item %}
                       <a href="javascript:;"
-                         onclick="context_menu(this, [{'contains': {{ curr_contains_data|by_key:hdr_item }}, 'value': '{{ curr_item_data|by_key:hdr_item }}' }], 0, {{ container.id }}, null, false);">
+                         onclick="context_menu(this, [{'contains': {{ curr_contains_data|by_key:hdr_item }}, 'value': '{{ curr_item_data|by_key:hdr_item|escapejs }}' }], 0, {{ container.id }}, null, false);">
                         {{ curr_item_data|by_key:hdr_item }}
                         &nbsp;<span class="fa fa-caret-down" style="font-size: smaller;"></span>
                       </a>

--- a/qradar.json
+++ b/qradar.json
@@ -1357,10 +1357,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.Password",
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.Recipient Users.*",
                     "data_type": "string"
                 },

--- a/qradar.json
+++ b/qradar.json
@@ -44,7 +44,7 @@
             "data_type": "boolean",
             "description": "Verify server certificate",
             "order": 1,
-            "default": false
+            "default": true
         },
         "username": {
             "data_type": "string",

--- a/qradar.json
+++ b/qradar.json
@@ -20,7 +20,7 @@
     "python_version": "3.9, 3.13",
     "logo": "logo_ibmqradar.svg",
     "logo_dark": "logo_ibmqradar_dark.svg",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "app_config_render": "default",
     "configuration": {
         "device": {

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -20,6 +20,7 @@ import re
 import sys
 import time
 from datetime import datetime, timedelta
+from urllib.parse import quote
 
 import dateutil.parser
 import dateutil.tz
@@ -2641,7 +2642,8 @@ class QradarConnector(BaseConnector):
         # value to insert into ref set
         params["value"] = reference_set_value
 
-        response = self._call_api(f"reference_data/sets/{reference_set_name}", "post", action_result, params=params)
+        encoded_reference_set_name = quote(reference_set_name, safe="")
+        response = self._call_api(f"reference_data/sets/{encoded_reference_set_name}", "post", action_result, params=params)
 
         if phantom.is_fail(action_result.get_status()):
             self.debug_print("call_api failed: ", action_result.get_status())

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1849,6 +1849,9 @@ class QradarConnector(BaseConnector):
             i = 0
             headers = dict()
             to_stop_fetch = 0
+            if not count or count < 1:
+                self.debug_print(f"No positive result bound was provided; defaulting to {QRADAR_QUERY_HIGH_RANGE}")
+                count = QRADAR_QUERY_HIGH_RANGE
             while True:
                 self.save_progress(f"Current iteration: {i + 1}")
                 # Define the range for fetching the items from the search in the QRadar instance
@@ -2242,7 +2245,7 @@ class QradarConnector(BaseConnector):
             extracted_limit_list = re.findall(QRADAR_LIMIT_REGEX_MATCH_PATTERN, ariel_query, re.IGNORECASE)
 
             if extracted_limit_list:
-                final_count = int(extracted_limit_list[0])
+                final_count = int(extracted_limit_list[-1])
         except Exception:
             self.debug_print(f"Error occurred while extracting the LIMIT value from the ariel query string: {ariel_query}")
             self.debug_print(
@@ -2297,7 +2300,7 @@ class QradarConnector(BaseConnector):
             extracted_limit_list = re.findall(QRADAR_LIMIT_REGEX_MATCH_PATTERN, query, re.IGNORECASE)
 
             if extracted_limit_list:
-                final_count = int(extracted_limit_list[0])
+                final_count = int(extracted_limit_list[-1])
         except Exception:
             self.debug_print(f"Error occurred while extracting the LIMIT value from the ariel query string: {query}")
             self.debug_print("Fetching all results by default due to failure in fetching the value of the LIMIT value from the query string")
@@ -2466,7 +2469,7 @@ class QradarConnector(BaseConnector):
             extracted_limit_list = re.findall(QRADAR_LIMIT_REGEX_MATCH_PATTERN, ariel_query, re.IGNORECASE)
 
             if extracted_limit_list:
-                final_count = int(extracted_limit_list[0])
+                final_count = int(extracted_limit_list[-1])
         except Exception:
             self.debug_print(f"Error occurred while extracting the LIMIT value from the ariel query string: {ariel_query}")
             self.debug_print("Fetching entire data due to failure in fetching the value of the LIMIT value from the query string")

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1097,6 +1097,14 @@ class QradarConnector(BaseConnector):
         action_result.update_summary({QRADAR_JSON_TOTAL_OFFENSES: len_offenses})
 
         add_offense_id_to_name = self._config.get("add_offense_id_to_name", False)
+        failed_ingest_floor = None
+
+        def track_failed_offense(failed_offense, floor):
+            try:
+                timestamp = min(int(failed_offense["start_time"]), int(failed_offense["last_updated_time"]))
+            except Exception:
+                return floor
+            return timestamp if floor is None else min(floor, timestamp)
 
         for i, offense in enumerate(offenses):
             # Clear the events list per an offense and artifact list
@@ -1156,9 +1164,11 @@ class QradarConnector(BaseConnector):
                 ):
                     self.save_progress("Aborting the polling process")
                     return action_result.set_status(phantom.APP_ERROR, error_message)
+                failed_ingest_floor = track_failed_offense(offense, failed_ingest_floor)
                 continue
 
             if not container_id:
+                failed_ingest_floor = track_failed_offense(offense, failed_ingest_floor)
                 continue
 
             if message == "Duplicate container found":
@@ -1259,15 +1269,23 @@ class QradarConnector(BaseConnector):
                 self.debug_print(f"Failed to get events for the offense ID: {offense_id}. Error message: {event_action_result.get_message()}")
                 self.save_progress(f"Failed to get events for the offense ID: {offense_id}. Error message: {event_action_result.get_message()}")
                 action_result.append_to_message(QRADAR_ERROR_GET_EVENTS_FAILED.format(offense_id=offense_id))
+                failed_ingest_floor = track_failed_offense(offense, failed_ingest_floor)
                 continue
 
             artifacts_creation_status, artifacts_creation_msg = self._ingest_collected_artifacts(offense_id)
             if phantom.is_fail(artifacts_creation_status):
                 self.debug_print("Logging the artifact creation failure for the current offense and continuing with the next offense")
                 self.debug_print(f"Error while creating artifacts for the Container ID {container_id}. Error: {artifacts_creation_msg}")
+                failed_ingest_floor = track_failed_offense(offense, failed_ingest_floor)
 
         # if we are polling, save the last ingested time
         if self._is_on_poll and not self._is_manual_poll:
+            if failed_ingest_floor is not None:
+                try:
+                    self._new_last_ingest_time = min(int(self._new_last_ingest_time), failed_ingest_floor)
+                except Exception:
+                    self._new_last_ingest_time = failed_ingest_floor
+                self.save_progress(f"Holding last_saved_ingest_time at {self._new_last_ingest_time} after an ingestion failure")
             self._state["last_saved_ingest_time"] = self._new_last_ingest_time
             try:
                 self.save_progress(

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -829,6 +829,10 @@ class QradarConnector(BaseConnector):
                 self.save_progress(QRADAR_PROG_GOT_X_OFFENSES, total_offenses=len(new_offenses))
                 break
 
+            if not count and len(offenses) >= QRADAR_QUERY_MAX_TOTAL_OFFENSES:
+                self.save_progress(f"Reached the maximum of {QRADAR_QUERY_MAX_TOTAL_OFFENSES} offenses; stopping pagination")
+                break
+
         self.save_progress(f"Total offenses discovered: {len(offenses)}")
 
         if len(offenses) > 0:
@@ -1506,6 +1510,10 @@ class QradarConnector(BaseConnector):
 
             if len(response.json()) < QRADAR_QUERY_HIGH_RANGE:
                 self.save_progress(QRADAR_PROG_GOT_X_OFFENSES, total_offenses=total_offenses)
+                break
+
+            if not count and total_offenses >= QRADAR_QUERY_MAX_TOTAL_OFFENSES:
+                self.save_progress(f"Reached the maximum of {QRADAR_QUERY_MAX_TOTAL_OFFENSES} offenses; stopping pagination")
                 break
 
         # Parse the output, which is an array of offenses

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1,6 +1,6 @@
 # File: qradar_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -741,7 +741,7 @@ class QradarConnector(BaseConnector):
         offenses = list()
 
         # create the filter to apply to query
-        ret_val, start_time, _, reqfilter, offenses_ids_list = self._createfilter(param, action_result)
+        ret_val, start_time, _, reqfilter, _offenses_ids_list = self._createfilter(param, action_result)
 
         if phantom.is_fail(ret_val):
             return action_result.get_status()

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1685,7 +1685,8 @@ class QradarConnector(BaseConnector):
                 return action_result.set_status(phantom.APP_ERROR, status_message)
 
             try:
-                rules += list_rules_response.json()
+                rules_chunk = list_rules_response.json()
+                rules += rules_chunk
             except Exception as e:
                 error_message = self._get_error_message_from_exception(e)
                 self.debug_print(QRADAR_ERROR_INVALID_JSON, error_message)
@@ -1693,8 +1694,12 @@ class QradarConnector(BaseConnector):
 
             total_rules = len(rules)
 
-            if len(rules) < QRADAR_QUERY_HIGH_RANGE:
+            if len(rules_chunk) < QRADAR_QUERY_HIGH_RANGE:
                 self.save_progress(QRADAR_PROG_GOT_X_RULES, total_offenses=total_rules)
+                break
+
+            if not count and total_rules >= QRADAR_QUERY_MAX_TOTAL_RULES:
+                self.save_progress(f"Reached the maximum of {QRADAR_QUERY_MAX_TOTAL_RULES} rules; stopping pagination")
                 break
 
         for rule in rules:

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -2491,6 +2491,8 @@ class QradarConnector(BaseConnector):
             return action_result.set_status(phantom.APP_SUCCESS, "No flows found")
 
         for data in self._all_flows_data:
+            if data.get("Password"):
+                data["Password"] = "[REDACTED]"
             action_result.add_data(data)
 
         action_result.update_summary({QRADAR_JSON_TOTAL_FLOWS: action_result.get_data_size()})

--- a/qradar_consts.py
+++ b/qradar_consts.py
@@ -123,6 +123,7 @@ QRADAR_CEF_VALUE_MAP_INT_PATTERN = r"numeric\((\d+(\.\d+)?)\)"
 
 # This value is set by trial and error by quering qradar
 QRADAR_QUERY_HIGH_RANGE = 1000
+QRADAR_QUERY_MAX_TOTAL_RULES = 100000
 QRADAR_BASIC_AUTH_ERROR_MESSAGE = "Please provide correct username and password in the asset configuration parameters"
 QRADAR_AUTH_TOKEN_ERROR_MESSAGE = "Please provide correct authorization token in the asset configuration parameters"
 QRADAR_ERROR_INVALID_PARAM = "Please provide non-zero positive integer in {param}"

--- a/qradar_consts.py
+++ b/qradar_consts.py
@@ -1,6 +1,6 @@
 # File: qradar_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/qradar_consts.py
+++ b/qradar_consts.py
@@ -124,6 +124,7 @@ QRADAR_CEF_VALUE_MAP_INT_PATTERN = r"numeric\((\d+(\.\d+)?)\)"
 # This value is set by trial and error by quering qradar
 QRADAR_QUERY_HIGH_RANGE = 1000
 QRADAR_QUERY_MAX_TOTAL_RULES = 100000
+QRADAR_QUERY_MAX_TOTAL_OFFENSES = 100000
 QRADAR_BASIC_AUTH_ERROR_MESSAGE = "Please provide correct username and password in the asset configuration parameters"
 QRADAR_AUTH_TOKEN_ERROR_MESSAGE = "Please provide correct authorization token in the asset configuration parameters"
 QRADAR_ERROR_INVALID_PARAM = "Please provide non-zero positive integer in {param}"

--- a/qradar_view.py
+++ b/qradar_view.py
@@ -1,6 +1,6 @@
 # File: qradar_view.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: refresh repository checks before connector updates.
+* Encode reference-set names as single QRadar API path segments.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Stop rule pagination on a short page and cap unbounded rule listings.
 * Cap unbounded offense pagination during ingestion and offense-detail retrieval.
 * Apply a finite default bound to Ariel result fetching when no valid limit is available.
+* Redact captured passwords before QRadar flow records enter action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Encode reference-set names as single QRadar API path segments.
 * Verify QRadar server certificates by default while retaining the explicit asset opt-out.
 * Escape QRadar widget values before embedding them in JavaScript context-menu handlers.
+* Stop rule pagination on a short page and cap unbounded rule listings.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Escape QRadar widget values before embedding them in JavaScript context-menu handlers.
 * Stop rule pagination on a short page and cap unbounded rule listings.
 * Cap unbounded offense pagination during ingestion and offense-detail retrieval.
+* Apply a finite default bound to Ariel result fetching when no valid limit is available.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Encode reference-set names as single QRadar API path segments.
 * Verify QRadar server certificates by default while retaining the explicit asset opt-out.
+* Escape QRadar widget values before embedding them in JavaScript context-menu handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: refresh repository checks before connector updates.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Encode reference-set names as single QRadar API path segments.
+* Verify QRadar server certificates by default while retaining the explicit asset opt-out.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 * Cap unbounded offense pagination during ingestion and offense-detail retrieval.
 * Apply a finite default bound to Ariel result fetching when no valid limit is available.
 * Redact captured passwords before QRadar flow records enter action results.
+* Hold polling checkpoints at failed offenses so later runs can retry their ingestion.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Verify QRadar server certificates by default while retaining the explicit asset opt-out.
 * Escape QRadar widget values before embedding them in JavaScript context-menu handlers.
 * Stop rule pagination on a short page and cap unbounded rule listings.
+* Cap unbounded offense pagination during ingestion and offense-detail retrieval.


### PR DESCRIPTION
### Bug Fixes

- Encode reference-set names as API path segments and verify TLS by default.
- Escape widget values, bound rules/offense/Ariel result collection, and retain failed-ingestion checkpoints.
- Redact captured password fields from flow action results and remove the password output datapath.

### Tracking

- PAPP: PAPP-37974 (ESPM-5228)
- PSAAS: PSAAS-30565, PSAAS-30730, PSAAS-30854, PSAAS-31818, PSAAS-32050, PSAAS-32322, PSAAS-32367, PSAAS-32394
- Provenance: VULN-93290/FS-994, VULN-93455/FS-1539, VULN-93579/FS-1667, VULN-94542/FS-3064, VULN-94774/FS-3297, VULN-95045/FS-3568, VULN-95090/FS-3613, VULN-95117/FS-3640

PSAAS-31681 and PSAAS-31724 are intentionally excluded: their read-only reports demonstrate data reads but no third-party mutation or SOAR vault write. No Jira labels were changed.

### Verification

- `pre-commit run --all-files` including Docker-backed dependency packaging
- `python3 -m py_compile qradar_connector.py qradar_consts.py qradar_view.py`
- `git diff --check origin/main..HEAD`

The supplied patches were treated as recommendations. Binary bytecode hunks were discarded; the implementation uses path encoding, output-context escaping, explicit pagination bounds, checkpoint retention, and final result redaction.

### Breaking changes

- QRadar assets now verify server certificates by default.
- `get flows` no longer declares or exposes captured password values.

### Manual Documentation

- [x] Generated action documentation was refreshed; no manual REST-handler or authentication documentation change is required.

---
Written by Codex for the ESPM-5228 connector vulnerability campaign.