### PR TITLE
fix: remediate QRadar July intake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.6
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -2644,7 +2644,7 @@ class QradarConnector(BaseConnector):
 
         action_result.add_data(response_json)
 
-        time_str = lambda x: datetime.fromtimestamp(int(x) / 1000.0).strftime("%Y-%m-%d %H:%M:%S UTC")
+        time_str = lambda x: self._datetime(int(x)).strftime("%Y-%m-%d %H:%M:%S UTC")
 
         try:
             # Create a summary
@@ -2789,7 +2789,7 @@ class QradarConnector(BaseConnector):
 
         action_result.add_data(response_json)
 
-        time_str = lambda x: datetime.fromtimestamp(int(x) / 1000.0).strftime("%Y-%m-%d %H:%M:%S UTC")
+        time_str = lambda x: self._datetime(int(x)).strftime("%Y-%m-%d %H:%M:%S UTC")
 
         try:
             # Create a summary

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -19,6 +19,7 @@ import calendar
 import re
 import sys
 import time
+import unicodedata
 from datetime import datetime, timedelta
 from urllib.parse import quote
 
@@ -407,6 +408,16 @@ class QradarConnector(BaseConnector):
         # Hence, fixing it using an already existing method.
         # datetime.fromtimestamp(long(epoch_milli) / 1000.0).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         return self._datetime(epoch_milli).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    def _sanitize_ingested_value(self, value):
+        if isinstance(value, str):
+            value = value.strip(" \r\n").replace("\u0000", "")
+            return "".join(character for character in value if unicodedata.category(character) != "Cf")
+        if isinstance(value, dict):
+            return {key: self._sanitize_ingested_value(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._sanitize_ingested_value(item) for item in value]
+        return value
 
     def _get_artifact(self, event, container_id):
         cef = phantom.get_cef_data(event, self._cef_event_map)
@@ -1119,9 +1130,7 @@ class QradarConnector(BaseConnector):
             # Replace the 'null' string to None if any
             offense = dict([(x[0], None if x[1] == "null" else x[1]) for x in list(offense.items())])
 
-            # Strip \r, \n and space from the values, QRadar does that for the description field at least
-            v_strip = lambda v: v.strip(" \r\n").replace("\u0000", "") if isinstance(v, str) else v
-            offense = dict([(k, v_strip(v)) for k, v in list(offense.items())])
+            offense = self._sanitize_ingested_value(offense)
 
             # Don't want dumping non None
             self.debug_print("Offense", phantom.remove_none_values(offense))
@@ -2011,14 +2020,10 @@ class QradarConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _create_events_artifacts(self, events, offense_id):
-        # To strip \r, \n and space from the values
-        v_strip = lambda v: v.strip(" \r\n").replace("\u0000", "") if isinstance(v, str) else v
-
         self._create_offense_artifacts(self._offense_details, self._container_id, offense_id)
 
         for event in events:
-            # strip \r, \n and space from the values, QRadar does that for the description field at least
-            event = dict([(k, v_strip(v)) for k, v in list(event.items())])
+            event = self._sanitize_ingested_value(event)
 
             artifact = self._get_artifact(event, self._container_id)
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Render QRadar offense summary timestamps in UTC.
+* Remove Unicode format-control characters from ingested QRadar values.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Refresh development tooling before QRadar remediation.
+* Render QRadar offense summary timestamps in UTC.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Refresh development tooling before QRadar remediation.


### PR DESCRIPTION
### Bug Fixes

* Render offense detail and close-offense summary timestamps in UTC.
* Remove Unicode format-control characters from ingested offense and event values.

### Tracking

* PAPP: PAPP-38287 (ESPM-5228)
* PSAAS: PSAAS-32794, PSAAS-33252
* Provenance: VULN-95787/FS-4481, VULN-96823/FS-5406

PSAAS-32552 is intentionally deferred pending a product decision on the Ariel search timeout.

### Verification

* `pre-commit run --all-files` with dev-cicd-tools v2.2.8 using public PyPI and Python 3.13
* `python3.13 -m py_compile qradar_connector.py qradar_consts.py qradar_view.py`
* `git diff --check origin/main..HEAD`

No BaseConnector unit-test files were added because the SOAR runtime modules are unavailable outside a SOAR instance.

---
Written by Codex for the ESPM-5228 connector vulnerability campaign.