### PR TITLE
fix: remediate qradar ingestion and response handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.42.1
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ sections.
     the parameter [alternative_ingest_algorithm] is set to true then, the offenses will be
     fetched according to [alt_ingest_order] and [alt_time_field] parameters. This
     configuration parameter is used in the List Offenses, Offense Details as well as in the On
-    Poll action.
+    Poll action. Scheduled On Poll runs always fetch oldest first so a bounded result set cannot
+    advance the ingestion checkpoint past offenses that were not fetched.
 
   - **events_ingest_start_time -** This parameter is optional and the default value is 60. This
     parameter defines the relative number of minutes (in milliseconds) to back-date the
@@ -564,7 +565,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **alternative_ingest_algorithm** | optional | boolean | Alternative ingest algorithm for offenses |
 **alt_time_field** | optional | string | Alternative ingestion time field |
 **alt_initial_ingest_time** | optional | string | Alternative initial ingestion time |
-**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses |
+**alt_ingestion_order** | optional | string | Alternative ingestion order for offenses; scheduled polling uses oldest first to preserve capped results |
 **events_ingest_start_time** | optional | numeric | Events ingestion initial time (relative to offense start time, default is 60 min) |
 **offense_ingest_start_time** | optional | numeric | Offense ingestion initial time (relative to offense start time, default is 0 min) |
 **event_ingest_end_time** | optional | numeric | Events ingestion end time (relative to event ingestion start time, default is 0 min) |

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -140,7 +140,8 @@ sections.
     the parameter [alternative_ingest_algorithm] is set to true then, the offenses will be
     fetched according to [alt_ingest_order] and [alt_time_field] parameters. This
     configuration parameter is used in the List Offenses, Offense Details as well as in the On
-    Poll action.
+    Poll action. Scheduled On Poll runs always fetch oldest first so a bounded result set cannot
+    advance the ingestion checkpoint past offenses that were not fetched.
 
   - **events_ingest_start_time -** This parameter is optional and the default value is 60. This
     parameter defines the relative number of minutes (in milliseconds) to back-date the

--- a/qradar.json
+++ b/qradar.json
@@ -147,7 +147,7 @@
                 "oldest first",
                 "latest first"
             ],
-            "description": "Alternative ingestion order for offenses"
+            "description": "Alternative ingestion order for offenses; scheduled polling uses oldest first to preserve capped results"
         },
         "events_ingest_start_time": {
             "data_type": "numeric",

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1892,6 +1892,9 @@ class QradarConnector(BaseConnector):
         except Exception:
             return action_result.get_status(phantom.APP_ERROR, QRADAR_ERROR_INVALID_JSON)
 
+        if not isinstance(response_json, dict):
+            return action_result.set_status(phantom.APP_ERROR, QRADAR_ERROR_INVALID_JSON)
+
         # Now get the search id
         search_id = response_json.get("search_id")
 
@@ -1943,6 +1946,9 @@ class QradarConnector(BaseConnector):
             try:
                 response_json = response.json()
             except Exception:
+                return action_result.set_status(phantom.APP_ERROR, QRADAR_ERROR_INVALID_JSON)
+
+            if not isinstance(response_json, dict):
                 return action_result.set_status(phantom.APP_ERROR, QRADAR_ERROR_INVALID_JSON)
 
             if "status" not in response_json:

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -2337,10 +2337,12 @@ class QradarConnector(BaseConnector):
         # 6. We are removing this because it was causing only 1000 events to be fetched and no more than that.
         # This led into data loss while ingesting a data set which had more than 1000 events in a single offense
 
+        order_direction = "asc" if self._is_on_poll and not self._is_manual_poll else "desc"
+
         if param.get("total_events_count"):
-            where_clause += " order by STARTTIME desc limit {}".format(int(param.get("total_events_count")))
+            where_clause += " order by STARTTIME {} limit {}".format(order_direction, int(param.get("total_events_count")))
         else:
-            where_clause += f" order by STARTTIME desc limit {count}"
+            where_clause += f" order by STARTTIME {order_direction} limit {count}"
 
         # From testing queries, it was noticed that the START and STOP are required else the default
         # result returned by the REST API is of 60 seconds or so. Also, the time format needs to be in
@@ -2377,9 +2379,11 @@ class QradarConnector(BaseConnector):
             where_clause += f" starttime >= {event_start_time} and starttime <= {end_time_msecs} "
 
             if param.get("total_events_count"):
-                where_clause += "ORDER BY starttime DESC LIMIT {} LAST {} DAYS".format(int(param.get("total_events_count")), event_days)
+                where_clause += "ORDER BY starttime {} LIMIT {} LAST {} DAYS".format(
+                    order_direction, int(param.get("total_events_count")), event_days
+                )
             else:
-                where_clause += f"ORDER BY starttime DESC LIMIT {count} LAST {event_days} DAYS"
+                where_clause += f"ORDER BY starttime {order_direction} LIMIT {count} LAST {event_days} DAYS"
 
         if self._use_alt_ariel_query and where_clause.startswith("ORDER BY"):
             ariel_query = f"{ariel_query} {where_clause}"

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -611,7 +611,9 @@ class QradarConnector(BaseConnector):
         reqfilter = None
 
         # first determine if there are any offenses requested, if so, no need to limit time range
-        offense_ids_list = str(phantom.get_value(param, phantom.APP_JSON_CONTAINER_ID, phantom.get_value(param, QRADAR_JSON_OFFENSE_ID, "")))
+        offense_ids_value = phantom.get_value(param, phantom.APP_JSON_CONTAINER_ID, phantom.get_value(param, QRADAR_JSON_OFFENSE_ID, ""))
+        offense_ids_supplied = offense_ids_value is not None and str(offense_ids_value).strip().casefold() not in {"", "none"}
+        offense_ids_list = str(offense_ids_value) if offense_ids_supplied else ""
 
         # clean up the string and parse into list, assume whitespace and commas as separators
         if offense_ids_list:
@@ -627,6 +629,15 @@ class QradarConnector(BaseConnector):
                     self.debug_print(f"In Alternate Ingestion workflow for fetching offenses, the provided offense: {x} is not valid")
 
             offense_ids_list = interim_offense_ids_list
+
+            if not offense_ids_list:
+                return (
+                    action_result.set_status(phantom.APP_ERROR, "Please provide valid offense ID|s"),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
 
         if len(offense_ids_list) > 0:
             reqfilter = "({})".format(" or ".join(["id=" + str(x) for x in offense_ids_list]))

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -217,7 +217,13 @@ class QradarConnector(BaseConnector):
             # 1. Testing the basic auth workflow as here
             if "Authorization" in headers:
                 try:
-                    r = request_func(url, headers=headers, verify=config[phantom.APP_JSON_VERIFY], params=params)
+                    r = request_func(
+                        url,
+                        headers=headers,
+                        verify=config[phantom.APP_JSON_VERIFY],
+                        params=params,
+                        timeout=DEFAULT_REQUEST_TIMEOUT,
+                    )
                     if r.status_code != 200:
                         result.set_status(phantom.APP_ERROR, QRADAR_BASIC_AUTH_ERROR_MESSAGE)
                         return r
@@ -240,7 +246,13 @@ class QradarConnector(BaseConnector):
 
                 # Testing the auth token workflow
                 try:
-                    r = request_func(url, headers=headers, verify=config[phantom.APP_JSON_VERIFY], params=params)
+                    r = request_func(
+                        url,
+                        headers=headers,
+                        verify=config[phantom.APP_JSON_VERIFY],
+                        params=params,
+                        timeout=DEFAULT_REQUEST_TIMEOUT,
+                    )
                     if r.status_code != 200:
                         result.set_status(phantom.APP_ERROR, QRADAR_AUTH_TOKEN_ERROR_MESSAGE)
                         return r
@@ -252,7 +264,13 @@ class QradarConnector(BaseConnector):
                     return r
         else:
             try:
-                r = request_func(url, headers=headers, verify=config[phantom.APP_JSON_VERIFY], params=params)
+                r = request_func(
+                    url,
+                    headers=headers,
+                    verify=config[phantom.APP_JSON_VERIFY],
+                    params=params,
+                    timeout=DEFAULT_REQUEST_TIMEOUT,
+                )
             except Exception as e:
                 error_message = self._get_error_message_from_exception(e)
                 result.set_status(phantom.APP_ERROR, f"{QRADAR_ERROR_REST_API_CALL_FAILED}. {error_message}")

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -400,6 +400,24 @@ class QradarConnector(BaseConnector):
 
         return phantom.APP_SUCCESS
 
+    def _normalize_ingest_checkpoint(self, value, upper_bound):
+        try:
+            checkpoint = int(value)
+            upper_bound = int(upper_bound)
+        except Exception:
+            self.debug_print(f"Ignoring malformed ingestion checkpoint: {value}")
+            return None
+
+        if checkpoint < 0:
+            self.debug_print(f"Ignoring negative ingestion checkpoint: {checkpoint}")
+            return None
+
+        if checkpoint > upper_bound:
+            self.debug_print(f"Clamping future ingestion checkpoint {checkpoint} to {upper_bound}")
+            return upper_bound
+
+        return checkpoint
+
     def _get_str_from_epoch(self, epoch_milli):
         # Previous line of code was as provided below which was wrong because
         # it generated the datetime based on the local Phantom timezone,
@@ -566,8 +584,14 @@ class QradarConnector(BaseConnector):
             # 4. if nothing configured assume 24 hours ago
 
             try:
+                saved_checkpoint = None
                 if self._is_on_poll and not self._is_manual_poll:
-                    start_time = self._state.get("last_saved_ingest_time", self._config.get("alt_initial_ingest_time", "yesterday"))
+                    raw_checkpoint = self._state.get("last_saved_ingest_time")
+                    if raw_checkpoint is not None:
+                        saved_checkpoint = self._normalize_ingest_checkpoint(raw_checkpoint, int(time.time()) * 1000)
+                    start_time = saved_checkpoint
+                    if start_time is None:
+                        start_time = self._config.get("alt_initial_ingest_time", "yesterday")
                 else:
                     start_time = param.get("start_time", self._config.get("alt_initial_ingest_time", "yesterday"))
 
@@ -694,6 +718,9 @@ class QradarConnector(BaseConnector):
                             None,
                             None,
                         )
+
+                if saved_checkpoint is not None:
+                    start_time = self._normalize_ingest_checkpoint(start_time, end_time)
             except Exception:
                 action_result.set_status(phantom.APP_ERROR, QRADAR_ERROR_DATETIME_PARSE)
                 return phantom.APP_ERROR, None, None, None, None
@@ -1295,16 +1322,19 @@ class QradarConnector(BaseConnector):
                 except Exception:
                     self._new_last_ingest_time = failed_ingest_floor
                 self.save_progress(f"Holding last_saved_ingest_time at {self._new_last_ingest_time} after an ingestion failure")
-            self._state["last_saved_ingest_time"] = self._new_last_ingest_time
-            try:
-                self.save_progress(
-                    "Setting last_saved_ingest_time to: {} {}".format(
-                        self._state["last_saved_ingest_time"], self._utcctime(self._state["last_saved_ingest_time"])
+            poll_end = param.get(phantom.APP_JSON_END_TIME, int(time.time()) * 1000)
+            checkpoint = self._normalize_ingest_checkpoint(self._new_last_ingest_time, poll_end)
+            if checkpoint is not None:
+                self._state["last_saved_ingest_time"] = checkpoint
+                try:
+                    self.save_progress(
+                        "Setting last_saved_ingest_time to: {} {}".format(
+                            self._state["last_saved_ingest_time"], self._utcctime(self._state["last_saved_ingest_time"])
+                        )
                     )
-                )
-            except Exception as e:
-                error_message = self._get_error_message_from_exception(e)
-                self.debug_print(f"Error occurred: {error_message}")
+                except Exception as e:
+                    error_message = self._get_error_message_from_exception(e)
+                    self.debug_print(f"Error occurred: {error_message}")
             self.save_state(self._state)
 
         self.send_progress(" ")
@@ -1404,8 +1434,11 @@ class QradarConnector(BaseConnector):
         try:
             start_time_msecs = int(param.get(phantom.APP_JSON_START_TIME, end_time_msecs - (QRADAR_MILLISECONDS_IN_A_DAY * num_days)))
             if self._is_on_poll and not self._is_manual_poll:
-                if self._state.get("last_saved_ingest_time", {}):
-                    start_time_msecs = int(self._state["last_saved_ingest_time"])
+                saved_checkpoint = self._state.get("last_saved_ingest_time")
+                if saved_checkpoint is not None:
+                    normalized_checkpoint = self._normalize_ingest_checkpoint(saved_checkpoint, end_time_msecs)
+                    if normalized_checkpoint is not None:
+                        start_time_msecs = normalized_checkpoint
         except Exception as e:
             error_message = self._get_error_message_from_exception(e)
             return action_result.set_status(

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -856,6 +856,10 @@ class QradarConnector(BaseConnector):
         if ingestion_order != "latest first" and ingestion_order != "oldest first":
             ingestion_order = "latest first"
 
+        if self._is_on_poll and not self._is_manual_poll and ingestion_order == "latest first":
+            self.save_progress("Scheduled polling uses oldest-first offense ingestion to preserve capped results")
+            ingestion_order = "oldest first"
+
         # Define the sorting field on the basis of the 'ingestion_order'
         if ingestion_order == "oldest first":
             self.save_progress("Ingesting the oldest first")

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -2351,18 +2351,15 @@ class QradarConnector(BaseConnector):
                     where_clause += " and"
                 where_clause += f" InOffense({offense_id}) "
 
-            event_start_time = None
-            if self._is_on_poll and not self._is_manual_poll:
-                if self._state.get("last_ingested_events_data", {}).get(str(param.get("offense_id", ""))):
-                    event_start_time = int(self._state["last_ingested_events_data"].get(str(param.get("offense_id"))))
+            event_start_time = start_time_msecs
+            now = self._utcnow()
+            start = self._datetime(event_start_time)
+            diff = now - start
+            event_days = max(1, abs(diff.days) + 1 if diff.seconds != 0 else abs(diff.days))
 
-            if not event_start_time:
-                event_days = num_days
-            else:
-                now = self._utcnow()
-                start = self._datetime(event_start_time)
-                diff = now - start
-                event_days = abs(diff.days) + 1 if diff.seconds != 0 else abs(diff.days)
+            if len(where_clause):
+                where_clause += " and"
+            where_clause += f" starttime >= {event_start_time} and starttime <= {end_time_msecs} "
 
             if param.get("total_events_count"):
                 where_clause += "ORDER BY starttime DESC LIMIT {} LAST {} DAYS".format(int(param.get("total_events_count")), event_days)

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -1976,6 +1976,7 @@ class QradarConnector(BaseConnector):
             i = 0
             headers = dict()
             to_stop_fetch = 0
+            previous_events_count = 0
             if not count or count < 1:
                 self.debug_print(f"No positive result bound was provided; defaulting to {QRADAR_QUERY_HIGH_RANGE}")
                 count = QRADAR_QUERY_HIGH_RANGE
@@ -1997,6 +1998,11 @@ class QradarConnector(BaseConnector):
                     current_events_count = len(action_result.get_data())
 
                 to_stop_fetch = current_events_count % QRADAR_QUERY_HIGH_RANGE
+
+                if i > 0 and current_events_count == previous_events_count:
+                    self.save_progress("Stopping Ariel pagination because the result count did not advance")
+                    break
+                previous_events_count = current_events_count
 
                 if current_events_count == 0 or to_stop_fetch != 0 or (count and current_events_count >= count):
                     break

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -437,6 +437,40 @@ class QradarConnector(BaseConnector):
             return [self._sanitize_ingested_value(item) for item in value]
         return value
 
+    def _normalize_offense_records(self, offenses, action_result):
+        normalized = []
+        skipped = 0
+
+        for offense in offenses:
+            if not isinstance(offense, dict) or offense.get("description") is None:
+                skipped += 1
+                continue
+
+            if any(isinstance(offense.get(key), bool) for key in ("id", "start_time", "severity")):
+                skipped += 1
+                continue
+
+            try:
+                offense = dict(offense)
+                offense["id"] = int(offense["id"])
+                offense["start_time"] = int(offense["start_time"])
+                offense["severity"] = float(offense["severity"])
+            except (KeyError, TypeError, ValueError, OverflowError):
+                skipped += 1
+                continue
+
+            if offense["id"] < 0 or offense["start_time"] < 0:
+                skipped += 1
+                continue
+
+            normalized.append(offense)
+
+        if skipped:
+            self.debug_print(f"Skipped {skipped} malformed offense record(s)")
+            action_result.append_to_message(f"Skipped {skipped} malformed offense record(s).")
+
+        return normalized
+
     def _get_artifact(self, event, container_id):
         cef = phantom.get_cef_data(event, self._cef_event_map)
 
@@ -873,21 +907,23 @@ class QradarConnector(BaseConnector):
 
         self.save_progress(f"Total offenses discovered: {len(offenses)}")
 
+        offenses = self._normalize_offense_records(offenses, action_result)
+
         if len(offenses) > 0:
             self.save_progress(f"Ingesting {len(offenses)} offenses")
 
             # Save the last ingest time for the offense
             if self._is_on_poll and not self._is_manual_poll:
-                if ingestion_order == "latest first":
-                    if self._time_field == "either":
-                        self._new_last_ingest_time = max(offenses[0]["start_time"], offenses[0]["last_updated_time"])
-                    else:
-                        self._new_last_ingest_time = offenses[0][self._time_field]
-                else:
-                    if self._time_field == "either":
-                        self._new_last_ingest_time = max(offenses[-1]["start_time"], offenses[-1]["last_updated_time"])
-                    else:
-                        self._new_last_ingest_time = offenses[-1][self._time_field]
+                checkpoint_candidates = offenses if ingestion_order == "latest first" else reversed(offenses)
+                checkpoint_fields = ("start_time", "last_updated_time") if self._time_field == "either" else (self._time_field,)
+                for offense in checkpoint_candidates:
+                    try:
+                        timestamps = [int(offense[field]) for field in checkpoint_fields]
+                    except (KeyError, TypeError, ValueError, OverflowError):
+                        continue
+                    if all(timestamp >= 0 for timestamp in timestamps):
+                        self._new_last_ingest_time = max(timestamps)
+                        break
 
             # Removing the reverse logic as now the offenses are sorted in the API call itself
             # based on the provision provided in the API for the QRadar instances that we have decided
@@ -1576,6 +1612,9 @@ class QradarConnector(BaseConnector):
                 self.save_progress(f"Reached the maximum of {QRADAR_QUERY_MAX_TOTAL_OFFENSES} offenses; stopping pagination")
                 break
 
+        offenses = self._normalize_offense_records(offenses, action_result)
+        total_offenses = len(offenses)
+
         # Parse the output, which is an array of offenses
         # Update the summary
         if total_offenses == 0 and offense_ids != "None":
@@ -1595,11 +1634,18 @@ class QradarConnector(BaseConnector):
         # This new_last_ingest_time variable will be used only in the On_Poll action to store it in the last_saved_ingest_time of the state file
 
         if self._is_on_poll and not self._is_manual_poll and offenses:
-            offenses.sort(key=lambda x: x["start_time"])
-            recent_start_time = offenses[-1]["start_time"]
-            offenses.sort(key=lambda x: x["last_updated_time"])
-            recent_last_updated_time = offenses[-1]["last_updated_time"]
-            self._new_last_ingest_time = max(recent_start_time, recent_last_updated_time)
+            valid_times = []
+            for offense in offenses:
+                for key in ("start_time", "last_updated_time"):
+                    try:
+                        timestamp = int(offense[key])
+                    except (KeyError, TypeError, ValueError, OverflowError):
+                        continue
+                    if timestamp >= 0:
+                        valid_times.append(timestamp)
+
+            if valid_times:
+                self._new_last_ingest_time = max(valid_times)
 
         action_result.set_status(phantom.APP_SUCCESS, f"{offenses_status_msg}Total Offenses: {len(offenses)}")
         return action_result.get_status()

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -157,7 +157,7 @@ class QradarConnector(BaseConnector):
         if len(message) > 500:
             message = "Error while connecting to a server"
 
-        return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
+        return action_result.set_status(phantom.APP_ERROR, message)
 
     def _get_json_error_message(self, response, action_result):
         """This function is used to process json error response.

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -174,6 +174,9 @@ class QradarConnector(BaseConnector):
             error_message = self._get_error_message_from_exception(e)
             return RetVal(action_result.set_status(phantom.APP_ERROR, f"Unable to parse JSON response. Error: {error_message}"), None)
 
+        if not isinstance(resp_json, dict):
+            return f"Unexpected JSON error response from server. Status Code: {response.status_code}"
+
         error_code = resp_json.get("code", "Not Found")
         error_message = resp_json.get("message", "Not Found")
         error_description = resp_json.get("description", "Not Found")

--- a/qradar_connector.py
+++ b/qradar_connector.py
@@ -2786,7 +2786,7 @@ class QradarConnector(BaseConnector):
                 )
             return action_result.set_status(phantom.APP_ERROR, status_message)
 
-        self.debug_print("content-type", response.headers["content-type"])
+        self.debug_print("content-type", response.headers.get("content-type", ""))
 
         # Parse the output, which is details of an offense
         try:
@@ -2861,7 +2861,7 @@ class QradarConnector(BaseConnector):
                 )
             return action_result.set_status(phantom.APP_ERROR, status_message)
 
-        self.debug_print("content-type", response.headers["content-type"])
+        self.debug_print("content-type", response.headers.get("content-type", ""))
 
         # Parse the output, which is details of an offense
         try:

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Validate and clamp scheduled ingestion checkpoints to the current poll boundary.
+* Propagate HTML response failures as scalar action errors during offense and event ingestion.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -8,3 +8,4 @@
 * Return a clean action error when QRadar sends a non-object JSON error response.
 * Stop Ariel result pagination when an additional page makes no forward progress.
 * Reject non-object Ariel search creation and status responses with a clean action error.
+* Preserve explicit requested and checkpointed event time bounds in alternate Ariel queries.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -10,3 +10,4 @@
 * Reject non-object Ariel search creation and status responses with a clean action error.
 * Preserve explicit requested and checkpointed event time bounds in alternate Ariel queries.
 * Process capped alternate-ingestion offense batches oldest first during scheduled polling.
+* Fail closed when an explicitly supplied alternate-ingestion offense ID list contains no valid IDs.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Validate and clamp scheduled ingestion checkpoints to the current poll boundary.
 * Propagate HTML response failures as scalar action errors during offense and event ingestion.
 * Skip malformed offense records without aborting the remaining ingestion batch or corrupting its checkpoint.
+* Allow successful reference-set and close-offense responses to omit the optional Content-Type header.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Validate and clamp scheduled ingestion checkpoints to the current poll boundary.
 * Propagate HTML response failures as scalar action errors during offense and event ingestion.
+* Skip malformed offense records without aborting the remaining ingestion batch or corrupting its checkpoint.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 * Allow successful reference-set and close-offense responses to omit the optional Content-Type header.
 * Bound QRadar API requests with the connector's existing 30-second network timeout.
 * Return a clean action error when QRadar sends a non-object JSON error response.
+* Stop Ariel result pagination when an additional page makes no forward progress.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -11,3 +11,4 @@
 * Preserve explicit requested and checkpointed event time bounds in alternate Ariel queries.
 * Process capped alternate-ingestion offense batches oldest first during scheduled polling.
 * Fail closed when an explicitly supplied alternate-ingestion offense ID list contains no valid IDs.
+* Process capped event queries oldest first during scheduled polling so checkpoints do not skip unfetched events.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Propagate HTML response failures as scalar action errors during offense and event ingestion.
 * Skip malformed offense records without aborting the remaining ingestion batch or corrupting its checkpoint.
 * Allow successful reference-set and close-offense responses to omit the optional Content-Type header.
+* Bound QRadar API requests with the connector's existing 30-second network timeout.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Validate and clamp scheduled ingestion checkpoints to the current poll boundary.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -9,3 +9,4 @@
 * Stop Ariel result pagination when an additional page makes no forward progress.
 * Reject non-object Ariel search creation and status responses with a clean action error.
 * Preserve explicit requested and checkpointed event time bounds in alternate Ariel queries.
+* Process capped alternate-ingestion offense batches oldest first during scheduled polling.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 * Bound QRadar API requests with the connector's existing 30-second network timeout.
 * Return a clean action error when QRadar sends a non-object JSON error response.
 * Stop Ariel result pagination when an additional page makes no forward progress.
+* Reject non-object Ariel search creation and status responses with a clean action error.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Skip malformed offense records without aborting the remaining ingestion batch or corrupting its checkpoint.
 * Allow successful reference-set and close-offense responses to omit the optional Content-Type header.
 * Bound QRadar API requests with the connector's existing 30-second network timeout.
+* Return a clean action error when QRadar sends a non-object JSON error response.


### PR DESCRIPTION
### Bug Fixes

- Harden scheduled ingestion checkpoints, malformed offense isolation, capped oldest-first processing, and Ariel pagination progress.
- Normalize HTML and JSON failure handling, tolerate optional Content-Type headers, and bound HTTP requests with the existing timeout.
- Preserve explicit alternate-Ariel time bounds and fail closed when an explicitly supplied offense ID list has no valid IDs.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate

### Tracking

- PAPP: PAPP-38287
- Epic: ESPM-5228
- Support classification: Certified Apps
- PSAAS-33877 (VULN-100617 / FS-6922)
- PSAAS-34193 (VULN-101717 / FS-7701)
- PSAAS-34197 (VULN-101721 / FS-7705)
- PSAAS-34198 (VULN-101722 / FS-7706)
- PSAAS-34275 (VULN-101799 / FS-7783)
- PSAAS-34432 (VULN-101956 / FS-7939)
- PSAAS-34563 (VULN-102087 / FS-8070)
- PSAAS-35076 (VULN-103697 / FS-8630)
- PSAAS-35078 (VULN-103699 / FS-8632)
- PSAAS-35146 (VULN-104274 / FS-9023)
- PSAAS-35164 (VULN-104292 / FS-9041)
- PSAAS-35196 (VULN-104324 / FS-9073)
- PSAAS-35198 (VULN-104326 / FS-9075)

### Source Evidence

- Requests documents that production code should set a timeout and that an omitted timeout can wait indefinitely: https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
- IBM documents QRadar AQL START/STOP and LAST time criteria: https://www.ibm.com/docs/en/qradar-on-cloud?topic=language-time-criteria-in-aql-queries
- IBM documents comparison predicates in AQL WHERE clauses: https://www.ibm.com/docs/en/qradar-on-cloud?topic=structure-where-clause
- IBM documents the event and flow AQL fields used by these query paths: https://www.ibm.com/docs/en/qradar-on-cloud?topic=language-event-flow-simarc-fields-aql-queries
- No new semantic allowlist was introduced; offense and response checks are limited to structural validation at existing sinks.

### Checks

- `pre-commit autoupdate` (tooling update committed separately)
- `pre-commit run --all-files` (passed unskipped, including Docker dependency packaging, app linter, semgrep, generated docs, release notes, and static tests)
- `PYTHONPYCACHEPREFIX=/tmp/qradar-codex-pycache python -m compileall -q .` (passed)
- `git diff --check origin/main...HEAD` (passed)
- Integration tests were not awaited because connector integration labs are not a reliable campaign gate.

### Other information

Merge strategy: merge commit only; do not squash

Prepared and written by Codex.